### PR TITLE
Don't link to module if it doesn't already exist

### DIFF
--- a/src/codegen/planning/module.rs
+++ b/src/codegen/planning/module.rs
@@ -7,8 +7,7 @@ use crate::tao::form::{BuildInfo, BuildInfoExtension};
 use crate::tao::form::{Module, ModuleExtension};
 use crate::tao::{Implement, ImplementExtension};
 use zamm_yin::node_wrappers::CommonNodeTrait;
-use zamm_yin::tao::archetype::{Archetype, ArchetypeFormTrait, ArchetypeTrait};
-use zamm_yin::tao::form::FormTrait;
+use zamm_yin::tao::archetype::{Archetype, ArchetypeFormTrait};
 
 /// Generate code for a given module. Post-processing still needed.
 pub fn code_module(request: Implement, module: Module, parent: Archetype) -> String {
@@ -31,11 +30,7 @@ pub fn code_module(request: Implement, module: Module, parent: Archetype) -> Str
         if in_own_submodule(&child) {
             let child_submodule = match BuildInfo::from(child.id()).representative_module() {
                 Some(existing_module) => existing_module,
-                None => {
-                    let mut new_submodule = Module::new();
-                    new_submodule.set_most_prominent_member(&child.as_form());
-                    new_submodule
-                }
+                None => continue,
             };
             public_submodules.push(
                 (*ModuleExtension::implementation_name(&child_submodule).unwrap()).to_owned(),


### PR DESCRIPTION
Gets Yang 0.1.5 building again, even if it doesn't quite fix all the attribute tests there. However, there's not much hope of fixing those since there's no way to tell which concepts came from Yin or not. Besides, those don't really matter when it comes to actual working functionality. Yang 0.1.5 builds and runs on current yang, and that should be good enough for Semver.